### PR TITLE
Fix code so this will run with latest Galaxy versions

### DIFF
--- a/src/main/java/com/github/jmchilton/galaxybootstrap/BootStrapper.java
+++ b/src/main/java/com/github/jmchilton/galaxybootstrap/BootStrapper.java
@@ -95,10 +95,6 @@ public class BootStrapper {
           + buildLogPath(bootstrapLogDir,"common_startup.log") + " 2>&1");
     }
 
-    executeGalaxyScript("python scripts/fetch_eggs.py 1> "
-      + buildLogPath(bootstrapLogDir,"fetch_eggs.log") + " 2>&1");
-
- 
     if(galaxyProperties.isCreateDatabaseRequired()) {
       executeGalaxyScript("sh create_db.sh 1> " 
         + buildLogPath(bootstrapLogDir,"create_db.log") + " 2>&1");

--- a/src/test/java/com/github/jmchilton/galaxybootstrap/BootStrapperTest.java
+++ b/src/test/java/com/github/jmchilton/galaxybootstrap/BootStrapperTest.java
@@ -63,8 +63,7 @@ public class BootStrapperTest {
    */
   @Test
   public void testSpecificRevision() throws InterruptedException, IOException {
-    // Galaxy stable release for 2013.11.04 at https://bitbucket.org/galaxy/galaxy-dist
-    final String expectedRevision = "5e605ed6069fe4c5ca9875e95e91b2713499e8ca";
+    final String expectedRevision = "0079d3c5a85d4f5316a41628a2669c442ead02c4";
     final BootStrapper bootStrapper = new BootStrapper(
       DownloadProperties.forStableAtRevision(expectedRevision));
     


### PR DESCRIPTION
This fixes galaxy-bootstrap to work with newer Galaxy versions that don't use eggs.
